### PR TITLE
Implement live address suggestions using Google API

### DIFF
--- a/client/src/pages/address-form.tsx
+++ b/client/src/pages/address-form.tsx
@@ -47,6 +47,13 @@ export default function AddressForm() {
   // Debounced search for address suggestions
   const { data: suggestions, isLoading: isSuggestionsLoading } = useQuery({
     queryKey: ["/api/places/suggestions", searchQuery],
+    queryFn: async (): Promise<SuggestionsResponse> => {
+      const res = await apiRequest(
+        "GET",
+        `/api/places/suggestions?input=${encodeURIComponent(searchQuery)}`,
+      );
+      return res.json();
+    },
     enabled: searchQuery.length >= 3,
     staleTime: 30000, // Cache for 30 seconds
   });


### PR DESCRIPTION
## Summary
- wire up address suggestion search to call the server with the correct query

## Testing
- `npm install --ignore-scripts`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68815e747974832583eca89ab6fcdae0